### PR TITLE
Feature/cli 2020 script encoding fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,40 +2,31 @@ FROM openjdk:jre-alpine
 
 LABEL Miguel Freitas <miguel.freitas@checkmarx.com>
 
-# Example of how to include certificate to java certificate store if needed
-# By Joao Costa <joao.costa@checkmarx.com>
-# Place .crt file in the same folder as your Dockerfile, CA certificate as the example below
-#     ARG CACERT="asterisk.crt"
-# Copy the certificate to the docker machine
-#     COPY $CACERT /opt/workdir/
-# Run command to apply the cetificate to java certificate store
-#     RUN keytool -importcert -file $CACERT -alias $CACERT -keystore cacerts -storepass changeit -noprompt
+ARG CX_CLI_URL="https://download.checkmarx.com/9.0.0/Plugins/cli-2020.1.12.zip"
 
-#ARG CX_CLI_VERSION="8.60.3"
-#ARG CX_CLI_VERSION="8.70.4"
-#ARG CX_CLI_VERSION="8.80.2"
-ARG CX_CLI_VERSION="8.90.2"
-
-#ARG CX_VERSION="8.6.0"
-#ARG CX_VERSION="8.7.0"
-#ARG CX_VERSION="8.8.0"
-ARG CX_VERSION="8.9.0"
-ARG CX_CLI_URL="https://download.checkmarx.com/${CX_VERSION}/Plugins/CxConsolePlugin-${CX_CLI_VERSION}.zip"
-
-RUN apk add --no-cache --update curl python jq bash
+RUN apk add --no-cache --update curl python jq bash && \
+    rm -rf /var/cache/apk/*
 
 WORKDIR /opt
 
+COPY *.crt *.cer import_certs.sh /certs/
+
 RUN curl ${CX_CLI_URL} -o cli.zip && \
-    rm -rf /var/cache/apk/* && \
     unzip cli.zip && \
     rm -rf cli.zip && \
-    mv CxConsolePlugin-${CX_CLI_VERSION} cxcli && \
+    mv CxConsolePlugin-* cxcli && \
     cd cxcli && \
+    # Fix DOS/Windows EOL encoding, if it exists
+    cat -v runCxConsole.sh | sed -e "s/\^M$//" > runCxConsole-fixed.sh && \
+    rm -f runCxConsole.sh && \
+    mv runCxConsole-fixed.sh runCxConsole.sh && \
     rm -rf Examples && \
     chmod +x runCxConsole.sh && \
-    chmod +x runCxConsole.cmd
+    /certs/import_certs.sh && \
+    rm -rf /certs
+
 
 WORKDIR /opt/cxcli
 
-CMD ["sh", "runCxConsole.sh", "Scan"]
+ENTRYPOINT ["/opt/cxcli/runCxConsole.sh"]
+

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 https://hub.docker.com/r/miguelfreitas93/cxcli
 
 ### Download Links:
+9.00.0 (latest) : https://download.checkmarx.com/9.0.0/Plugins/cli-2020.1.12.zip
 
-8.90.2 (latest): https://download.checkmarx.com/8.9.0/Plugins/CxConsolePlugin-8.90.2.zip
+8.90.2 : https://download.checkmarx.com/8.9.0/Plugins/CxConsolePlugin-8.90.2.zip
 
 8.80.2 : https://download.checkmarx.com/8.8.0/Plugins/CxConsolePlugin-8.80.2.zip
 
@@ -17,9 +18,22 @@ https://hub.docker.com/r/miguelfreitas93/cxcli
 
 https://checkmarx.atlassian.net/wiki/spaces/KC/pages/44335590/CxSAST+CLI+Guide
 
-### Build:
+
+### Importing Custom CA Certificates
+
+Any binary DER encoded X.509 certificates in files ending in *.cer or *.crt will be imported from the build directory at the time the image build is executed.
+
+### Build with latest plugin:
 
 docker build -t cxcli:{version} . --no-cache
+
+### Build with an older version of the plugin:
+
+*Insert a download URL from above to change the plugin version.*
+
+docker build --build-arg CX_CLI_URL="{download url}" -t cxcli:{version} . --no-cache
+
+
 
 ### Run Container:
 

--- a/import_certs.sh
+++ b/import_certs.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cd `dirname $0`
+
+for certfile in $(ls *.crt *.cer 2> /dev/null)
+do
+    keytool -importcert -file $certfile -alias $certfile -keystore $JAVA_HOME/lib/security/cacerts -storepass changeit -noprompt
+done


### PR DESCRIPTION
Added default to use latest CLI plugin.
Added method of building with old or new version that works with the new file naming convention for 9.0.
Added ability to import custom CA certs automatically during the build.
Added a workaround to fix the Windows EOL encoding of the runCxConsole.sh to work with bash.
Changed to use the runCxConsole.sh as the entrypoint.